### PR TITLE
1-indexed `vector` and `matrix`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To use the data structures and math modules provided by `simutils`, simply inclu
 
 ## Vectors and Matrices
 
-`simutils` comes with a two very helpful data structures, `vector` and `matrix`. The advantage of using `vector` and `matrix` instead of single `int*` or double `float**` pointers is that both `vector` and `matrix` carry along their size information (like how you could with a `struct`), while still preserving the ability to be directly indexed (like a array defined from a pointer).
+`simutils` comes with a two very helpful data structures, `vector` and `matrix`. The advantage of using `vector` and `matrix` instead of single `int*` or double `float**` pointers is that both `vector` and `matrix` carry along their size information (like how you could with a `struct`), while still preserving the ability to be directly indexed (like a array defined from a pointer). Also, both `vector` and `matrix` types are **1-indexed** such that representing mathematical models and operations is more intuitive.
 
 ### Using `vector`
 
@@ -26,8 +26,8 @@ int main(int argc, char** argv) {
     vector vec = make_vector(4);
 
     // set the first and last elements to 1
-    vec[0] = 1.;
-    vec[3] = 1.;
+    vec[1] = 1.;
+    vec[4] = 1.;
 
     // print the vector to stdout
     print_vector(vec);
@@ -69,8 +69,8 @@ int main(int argc, char** argv) {
     matrix mat = make_matrix(4, 3);
 
     // set some elements to 1
-    mat[0][1] = 1.;
     mat[1][1] = 1.;
+    mat[4][3] = 1.;
 
     // print the matrix to stdout
     print_matrix(mat);

--- a/matrix.c
+++ b/matrix.c
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include <stdio.h>
+
 #include "matrix.h"
 #include "error.h"
 

--- a/matrix.c
+++ b/matrix.c
@@ -87,10 +87,10 @@ void print_matrix(matrix mat) {
     for (int i = 0; i < nrow; i++) {
         printf("[");
         for (int j = 0; j < ncol; j++) {
-            (j == nrow) ? printf("%6.3f", mat[i][j]) :
+            (j == ncol-1) ? printf("%6.3f", mat[i][j]) :
                           printf("%6.3f, ", mat[i][j]);
         }
-        (i == ncol) ? printf("]") :
+        (i == nrow-1) ? printf("]") :
                       printf("]\n ");
     }
     printf("]\n");

--- a/matrix.h
+++ b/matrix.h
@@ -5,7 +5,8 @@
 
 typedef double** matrix;
 
-#define MATRIX_SIZE_BYTE (size_t)(sizeof(unsigned int)*2)
+#define MATRIX_SIZE_BYTE  (size_t)(sizeof(unsigned int)*2)
+#define MATRIX_ROW_OFFSET (size_t)(sizeof(double*))
 
 /**
  * @brief Macro to access the size byte of the matrix
@@ -36,7 +37,7 @@ typedef double** matrix;
                     "Unmatching matrix dimensions for matrix creation!\n");\
         for (int i = 0; i < (int)row; i++) {\
             for (int j = 0; j < (int)col; j++) {\
-                targ[i][j] = from[i][j];\
+                targ[i+1][j+1] = from[i][j];\
             }\
         }\
     } while(0)

--- a/matrix.h
+++ b/matrix.h
@@ -2,6 +2,7 @@
 #define SIMUTIL_MATRIX_H
 
 #include "error.h"
+
 typedef double** matrix;
 
 #define MATRIX_SIZE_BYTE (size_t)(sizeof(unsigned int)*2)
@@ -10,11 +11,17 @@ typedef double** matrix;
  * @brief Macro to access the size byte of the matrix
  *
  */
-#define ROWS(mat) \
+/* #define ROWS(mat) \
     *( ((unsigned int*)((char*)mat - MATRIX_SIZE_BYTE))+0 )
 
 #define COLS(mat) \
-    *( ((unsigned int*)((char*)mat - MATRIX_SIZE_BYTE))+1 )
+    *( ((unsigned int*)((char*)mat - MATRIX_SIZE_BYTE))+1 ) */
+
+#define ROWS(mat) \
+    *( (char*)mat - MATRIX_SIZE_BYTE + sizeof(unsigned int)*0 )
+
+#define COLS(mat) \
+    *( (char*)mat - MATRIX_SIZE_BYTE + sizeof(unsigned int)*1 )
 
 /**
  * @brief Macro to create a new matrix based on an existing stack-allocated

--- a/matrix.h
+++ b/matrix.h
@@ -1,6 +1,7 @@
 #ifndef SIMUTIL_MATRIX_H
 #define SIMUTIL_MATRIX_H
 
+#include "error.h"
 typedef double** matrix;
 
 #define MATRIX_SIZE_BYTE (size_t)(sizeof(unsigned int)*2)
@@ -14,6 +15,24 @@ typedef double** matrix;
 
 #define COLS(mat) \
     *( ((unsigned int*)((char*)mat - MATRIX_SIZE_BYTE))+1 )
+
+/**
+ * @brief Macro to create a new matrix based on an existing stack-allocated
+ * matrix. Assumes that there is already an existing pointer to the matrix
+ * 'targ' that is the same size as the static matrix.
+ *
+ */
+#define FROM_MATRIX(from, targ, row, col)\
+    do {\
+        if (ROWS(targ) != row || COLS(targ) != col)\
+            raise_error(SIMUTIL_DIMENSION_ERROR,\
+                    "Unmatching matrix dimensions for matrix creation!\n");\
+        for (int i = 0; i < (int)row; i++) {\
+            for (int j = 0; j < (int)col; j++) {\
+                targ[i][j] = from[i][j];\
+            }\
+        }\
+    } while(0)
 
 /**
  * @brief Function to create a new matrix with a given size

--- a/vector.c
+++ b/vector.c
@@ -12,12 +12,14 @@
 
 #define INIT_VECTOR(mem, out, size) \
     do {\
-        out = (vector)( (char*)mem + VECTOR_SIZE_BYTE );\
+        out = (vector)( (char*)mem + VECTOR_SIZE_BYTE + VECTOR_IDX_BYTE );\
         *( ((unsigned int*)mem)+0 ) = size;\
+        out--;\
     } while(0)
 
 vector new_vector(unsigned int size) {
-    void* vec_mem = calloc(1, size*sizeof(double)+VECTOR_SIZE_BYTE);
+    void* vec_mem = calloc(1, size*sizeof(double) + VECTOR_SIZE_BYTE
+                                                  + VECTOR_IDX_BYTE);
     CHECK(vec_mem);
     vector out;
     INIT_VECTOR(vec_mem, out, size);
@@ -42,7 +44,6 @@ void add(vector vec1, vector vec2) {
         exit(EXIT_FAILURE);
     }
     const int len = LENGTH(vec1);
-#pragma omp for simd
     for (int i = 0; i < len; i++) {
         vec1[i] += vec2[i];
     }
@@ -67,8 +68,9 @@ vector read_vector(const char *filename) {
         exit(EXIT_FAILURE);
     }
     vector out;
-    void* vec_mem = calloc(1, size*sizeof(double)+VECTOR_SIZE_BYTE);
-    CHECK(vec_mem);\
+    void* vec_mem = calloc(1, size*sizeof(double) + VECTOR_SIZE_BYTE
+                                                  + VECTOR_IDX_BYTE);
+    CHECK(vec_mem);
     INIT_VECTOR(vec_mem, out, size);
     if (!fread(out, sizeof(double), size, file)) {
         raise_error(SIMUTIL_ALLOCATE_ERROR, "Problem reading the 'vec'.");
@@ -80,7 +82,7 @@ vector read_vector(const char *filename) {
 }
 
 void free_vector(vector vec) {
-    void* vec_mem = (void*)( (char*)vec - VECTOR_SIZE_BYTE );
+    void* vec_mem = (void*)( (char*)vec - VECTOR_SIZE_BYTE);
     free(vec_mem);
     vec_mem = NULL;
 }
@@ -88,12 +90,14 @@ void free_vector(vector vec) {
 void grow_vector(vector* vec, double elem) {
     CHECK(vec);
     const unsigned int new_size = LENGTH(*vec)+1;
-    void* vec_mem = (void*)( (char*)*vec - VECTOR_SIZE_BYTE );
-    void* new_vec_mem = realloc(vec_mem, (new_size)*sizeof(double)+VECTOR_SIZE_BYTE);
+    void* vec_mem = (void*)( (char*)*vec - VECTOR_SIZE_BYTE);
+    void* new_vec_mem = realloc(vec_mem,
+                                (new_size)*sizeof(double) + VECTOR_SIZE_BYTE
+                                                          + VECTOR_IDX_BYTE);
     CHECK(new_vec_mem);
     vector out;
     INIT_VECTOR(new_vec_mem, out, new_size);
-    out[new_size-1] = elem;
+    out[new_size] = elem;
     *vec = out;
 }
 
@@ -104,8 +108,8 @@ unsigned int get_length(vector vec) {
 void print_vector(vector vec) {
     const int size = (int)LENGTH(vec);
     printf("[");
-    for (int i = 0; i < size; i++) {
-        i != size-1 ? printf("%g, ", vec[i]) : 
+    for (int i = 1; i <= size; i++) {
+        i != size ? printf("%g, ", vec[i]) : 
                       printf("%g", vec[i]);
     }
     printf("]\n");

--- a/vector.c
+++ b/vector.c
@@ -91,8 +91,6 @@ void grow_vector(vector* vec, double elem) {
     void* vec_mem = (void*)( (char*)*vec - VECTOR_SIZE_BYTE );
     void* new_vec_mem = realloc(vec_mem, (new_size)*sizeof(double)+VECTOR_SIZE_BYTE);
     CHECK(new_vec_mem);
-    /* vector out = (vector)( (char*)new_vec_mem + VECTOR_SIZE_BYTE );
-    *(out-1) = (double)new_size; */
     vector out;
     INIT_VECTOR(new_vec_mem, out, new_size);
     out[new_size-1] = elem;

--- a/vector.c
+++ b/vector.c
@@ -24,16 +24,6 @@ vector new_vector(unsigned int size) {
     return out;
 }
 
-vector from_vector(double* s_vector, unsigned int size) {
-    void* vec_mem = calloc(1, size*sizeof(double)+VECTOR_SIZE_BYTE);
-    CHECK(vec_mem);
-    vector out;
-    INIT_VECTOR(vec_mem, out, size);
-    for (int i = 0; i < (int)size; i ++)
-        out[i] = s_vector[i];
-    return out;
-}
-
 void add_simd(vector vec1, vector vec2) {
     if (LENGTH(vec1) != LENGTH(vec2)) {
         raise_error(SIMUTIL_DIMENSION_ERROR, "Vector dimension mismatch.");

--- a/vector.c
+++ b/vector.c
@@ -24,6 +24,16 @@ vector new_vector(unsigned int size) {
     return out;
 }
 
+vector from_vector(double* s_vector, unsigned int size) {
+    void* vec_mem = calloc(1, size*sizeof(double)+VECTOR_SIZE_BYTE);
+    CHECK(vec_mem);
+    vector out;
+    INIT_VECTOR(vec_mem, out, size);
+    for (int i = 0; i < (int)size; i ++)
+        out[i] = s_vector[i];
+    return out;
+}
+
 void add_simd(vector vec1, vector vec2) {
     if (LENGTH(vec1) != LENGTH(vec2)) {
         raise_error(SIMUTIL_DIMENSION_ERROR, "Vector dimension mismatch.");

--- a/vector.c
+++ b/vector.c
@@ -12,8 +12,8 @@
 
 #define INIT_VECTOR(mem, out, size) \
     do {\
-        out = (vector)( (char*)mem + VECTOR_SIZE_BYTE + VECTOR_IDX_BYTE );\
         *( ((unsigned int*)mem)+0 ) = size;\
+        out = (vector)( (char*)mem + VECTOR_SIZE_BYTE + VECTOR_IDX_BYTE );\
         out--;\
     } while(0)
 
@@ -33,7 +33,7 @@ void add_simd(vector vec1, vector vec2) {
     }
     const int len = LENGTH(vec1);
 #pragma omp for simd
-    for (int i = 0; i < len; i++) {
+    for (int i = 1; i <= len; i++) {
         vec1[i] += vec2[i];
     }
 }
@@ -44,7 +44,7 @@ void add(vector vec1, vector vec2) {
         exit(EXIT_FAILURE);
     }
     const int len = LENGTH(vec1);
-    for (int i = 0; i < len; i++) {
+    for (int i = 1; i <= len; i++) {
         vec1[i] += vec2[i];
     }
 }

--- a/vector.h
+++ b/vector.h
@@ -5,6 +5,8 @@ typedef double* vector;
 
 #define VECTOR_SIZE_BYTE (size_t)(sizeof(unsigned int)*1)
 
+#define VECTOR_IDX_BYTE  (size_t)(sizeof(vector)*1)
+
 /**
  * @brief Macro to access the size byte of the vector
  *
@@ -26,7 +28,7 @@ typedef double* vector;
             raise_error(SIMUTIL_DIMENSION_ERROR,\
                     "Unmatching dimensions for vector creation!\n");\
         for (int i = 0; i < (int)size; i++) {\
-            targ[i] = from[i];\
+            targ[i+1] = from[i];\
         }\
     } while(0)
 

--- a/vector.h
+++ b/vector.h
@@ -14,6 +14,23 @@ typedef double* vector;
 #define LENGTH(vec) \
     *( (unsigned int*)(((char*)vec - VECTOR_SIZE_BYTE))+0 ) 
 
+/**
+ * @brief Macro to create a new vector based on an existing stack-allocated
+ * vector. Assumes that there is already an existing pointer to the vector
+ * 'targ' that is the same size as the static vector.
+ *
+ */
+#define FROM_VECTOR(from, targ, size)\
+    do {\
+        if (LENGTH(targ) != size)\
+            raise_error(SIMUTIL_DIMENSION_ERROR,\
+                    "Unmatching dimensions for vector creation!\n");\
+        for (int i = 0; i < (int)size; i++) {\
+            targ[i] = from[i];\
+        }\
+    } while(0)
+
+
 void add(vector vec1, vector vec2);
 void add_simd(vector vec1, vector vec2);
 
@@ -24,14 +41,6 @@ void add_simd(vector vec1, vector vec2);
  * @return vector Double pointer to a new vector
  */
 vector new_vector(unsigned int size);
-
-/**
- * @brief Function to create a new vector from a static array
- *
- * @param s_vector Pointer to a static array
- * @return Double pointer to a new vector
- */
-vector from_vector(double* s_vector, unsigned int size);
 
 /**
  * @brief Function to properly free the memory allocated to the vector

--- a/vector.h
+++ b/vector.h
@@ -26,6 +26,14 @@ void add_simd(vector vec1, vector vec2);
 vector new_vector(unsigned int size);
 
 /**
+ * @brief Function to create a new vector from a static array
+ *
+ * @param s_vector Pointer to a static array
+ * @return Double pointer to a new vector
+ */
+vector from_vector(double* s_vector, unsigned int size);
+
+/**
  * @brief Function to properly free the memory allocated to the vector
  *
  * @param vec Vector to free


### PR DESCRIPTION
# `vector` and `matrix` types are now **1-indexed** :)
In order for more seamless integration into the scientific programming paradigm, `vector` and `matrix` types are now 1-indexed.